### PR TITLE
remove unneeded 'jekyll-remote-theme' plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,6 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jemoji
-  - jekyll-remote-theme
 
 author:
   name   : "Michael Rose"


### PR DESCRIPTION
No need for that now.

Updating this file will also mean that the demo site will rebuild and update to latest version of the theme and Jekyll.